### PR TITLE
Deduplicate contacts when printing

### DIFF
--- a/charrington.py
+++ b/charrington.py
@@ -454,5 +454,9 @@ if __name__ == "__main__":
         # sort and remove dups
         contacts.sort(key=lambda x : x.last_name.lower())
         
+        printed = set()
         for contact in contacts:
+            if contact.id in printed:
+                continue
             print(format_contact_bbdb(contact).encode("utf-8"))
+            printed.add(contact.id)


### PR DESCRIPTION
Hi Deon,

I found this tool from your blog and it seems like it might solve a problem that has been plaguing me for ages.

I did have some problems with BBDB messages about duplicates, so here is a small fix to prevent the printing of the same contact if they appear in multiple groups.

Thanks,
Russell
